### PR TITLE
Fix popup messaging by injecting content scripts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   "author": "Jerome Wu <jeromewus@gmail.com>",
   "permissions": [
     "declarativeContent",
-    "activeTab"
+    "activeTab",
+    "scripting"
   ],
   "background": { "service_worker": "bg.js" },
   "action": {

--- a/popup.js
+++ b/popup.js
@@ -2,8 +2,18 @@
 
 document.getElementById('start').addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const tabId = tabs[0].id;
     const url = document.getElementById('video-url').value;
-    chrome.tabs.sendMessage(tabs[0].id, { action: 'transcode', url });
+
+    chrome.scripting.executeScript(
+      {
+        target: { tabId },
+        files: ['vendor/ffmpeg.min.js', 'vendor/ffmpeg-core.js', 'transcode.js'],
+      },
+      () => {
+        chrome.tabs.sendMessage(tabId, { action: 'transcode', url });
+      }
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- enable `scripting` permission
- load content scripts with `chrome.scripting.executeScript` before sending messages

## Testing
- `npm test` *(fails: `package.json` not found)*